### PR TITLE
zfit.pdf.ZPDF extension classes for standard SiPM response models

### DIFF
--- a/src/sipmpdf/functions.py
+++ b/src/sipmpdf/functions.py
@@ -529,7 +529,7 @@ def _k_summation(x: np.float64, common_noise: np.float64,
   return kern.sum(
     generalized_poisson(k=idk, mean=poisson_mean, borel=poisson_borel) *
     _full_afterpulse_response(x=x,
-                              total=total,
+                              total=idk,
                               ap_smear=common_noise,
                               ap_beta=ap_beta,
                               ap_prob=ap_prob,
@@ -615,8 +615,7 @@ def sipm_response_no_dark(x: np.float64,
                           poisson_mean: np.float64,
                           poisson_borel: np.float64,
                           ap_prob: np.float64,
-                          ap_beta: np.float64,
-                          dc_res: np.float64 = 1e-4) -> np.float64:
+                          ap_beta: np.float64) -> np.float64:
   """
   SiPM low light probability density function, excluding dark current effects.
   

--- a/src/sipmpdf/pdf.py
+++ b/src/sipmpdf/pdf.py
@@ -1,0 +1,49 @@
+"""
+pdf.py
+
+SiPM response functions as a zfit.pdf.ZPDF extended class for user level fits.
+
+"""
+
+import zfit
+from . import functions as f
+
+
+class SiPMResponse_NoDCAP_PDF(zfit.pdf.ZPDF):
+  _N_OBS = 1
+  _PARAMS = [
+    'pedestal', 'gain', 'common_noise', 'pixel_noise', 'poisson_mean',
+    'poisson_borel'
+  ]
+
+  def _unnormalized_pdf(self, x):
+    x = zfit.z.unstack_x(x)
+    return f.sipm_response_no_dark_no_ap(
+      x, **{k: self.params[k]
+            for k in self._PARAMS})
+
+
+class SiPMResponse_NoDC_PDF(zfit.pdf.ZPDF):
+  _N_OBS = 1
+  _PARAMS = [
+    'pedestal', 'gain', 'common_noise', 'pixel_noise', 'poisson_mean',
+    'poisson_borel', 'ap_prob', 'ap_beta'
+  ]
+
+  def _unnormalized_pdf(self, x):
+    x = zfit.z.unstack_x(x)
+    return f.sipm_response_no_dark(x,
+                                   **{k: self.params[k]
+                                      for k in self._PARAMS})
+
+
+class SiPMResponsePDF(zfit.pdf.ZPDF):
+  _N_OBS = 1
+  _PARAMS = [
+    'pedestal', 'gain', 'common_noise', 'pixel_noise', 'poisson_mean',
+    'poisson_borel', 'ap_prob', 'ap_beta', 'dc_prob', 'dc_res'
+  ]
+
+  def _unnormalized_pdf(self, x):
+    x = zfit.z.unstack_x(x)
+    return f.sipm_response(x, **{k: self.params[k] for k in self._PARAMS})


### PR DESCRIPTION
* new pdf.py file that implements the SiPM responses as zfit.pdf.ZPDF classes.